### PR TITLE
Switch from various version managers to mise

### DIFF
--- a/.config/direnv/direnvrc
+++ b/.config/direnv/direnvrc
@@ -1,9 +1,0 @@
-# Usage: use ruby <version>
-#
-# Loads the specified ruby version into the environment
-#
-use_ruby() {
-  local ruby_dir=$HOME/.rubies/$1
-  load_prefix $ruby_dir
-  layout ruby
-}

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -1,0 +1,4 @@
+[tools]
+node = "23"
+python = "3.12"
+uv = "latest"

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -1,4 +1,4 @@
 [tools]
 node = "23"
-python = "3.12"
+python = "3.13"
 uv = "latest"

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -1,4 +1,4 @@
 [tools]
-node = "23"
+node = "22"
 python = "3.13"
 uv = "latest"

--- a/.docs/PROJECT_LOCAL_CONFIGURATION.md
+++ b/.docs/PROJECT_LOCAL_CONFIGURATION.md
@@ -90,7 +90,11 @@ Individual projects can conflict with my general dotfiles settings. For example,
 my Vim autofix settings are liberal. When interacting with legacy projects
 without enforced code style, autofix can inflict a ton of noise.
 
-> ![CAUTION] Replace direnv with mise.
+:::caution
+
+Replace direnv with mise.
+
+:::
 
 I'm already using [direnv](https://direnv.net/) dotfiles for per-project
 environment variables. With 2 project folder dotfiles, .envrc and .vimrc.local,

--- a/.docs/PROJECT_LOCAL_CONFIGURATION.md
+++ b/.docs/PROJECT_LOCAL_CONFIGURATION.md
@@ -90,11 +90,9 @@ Individual projects can conflict with my general dotfiles settings. For example,
 my Vim autofix settings are liberal. When interacting with legacy projects
 without enforced code style, autofix can inflict a ton of noise.
 
-:::caution
-
-Replace direnv with mise.
-
-:::
+> ![CAUTION]
+>
+> Replace direnv with mise.
 
 I'm already using [direnv](https://direnv.net/) dotfiles for per-project
 environment variables. With 2 project folder dotfiles, .envrc and .vimrc.local,

--- a/.docs/PROJECT_LOCAL_CONFIGURATION.md
+++ b/.docs/PROJECT_LOCAL_CONFIGURATION.md
@@ -88,11 +88,12 @@ dependency of the project.
 
 Individual projects can conflict with my general dotfiles settings. For example,
 my Vim autofix settings are liberal. When interacting with legacy projects
-without enforced code style, autofix can inflict a ton of noise.
+without enforced code style, autofix can inflict a ton of noise. My editor ought
+to be configured per-project, instead of every project bending to me.
 
 > [!CAUTION]
 >
-> Replace direnv with mise.
+> **TODO:** Replace direnv with mise. The following is outdated.
 
 I'm already using [direnv](https://direnv.net/) dotfiles for per-project
 environment variables. With 2 project folder dotfiles, .envrc and .vimrc.local,

--- a/.docs/PROJECT_LOCAL_CONFIGURATION.md
+++ b/.docs/PROJECT_LOCAL_CONFIGURATION.md
@@ -90,7 +90,7 @@ Individual projects can conflict with my general dotfiles settings. For example,
 my Vim autofix settings are liberal. When interacting with legacy projects
 without enforced code style, autofix can inflict a ton of noise.
 
-> ![CAUTION]
+> [!CAUTION]
 >
 > Replace direnv with mise.
 

--- a/.docs/PROJECT_LOCAL_CONFIGURATION.md
+++ b/.docs/PROJECT_LOCAL_CONFIGURATION.md
@@ -19,49 +19,55 @@ the tool. Note the global tool will not necessarily have access to the project's
 ❎ **Python project-local tooling should be picked up automatically,** with
 caveats.
 
-Python project dependencies are _not_ conventionally stored within the project.
-Since I'm using [pyenv](https://github.com/pyenv/pyenv), while inside the
-project folder, I can set the virtualenv the project should use with
-`pyenv local <virtualenv-name-here>`. This activates the local Python install
-whenever you're inside the project folder. When editing project files,
-[vim-rooter](https://github.com/airblade/vim-rooter) should automatically `cd`
-into the folder, and therefore activate pyenv's local Python install, for Vim.
-Then ALE will use the local tool versions.
+Python project dependencies require an extra step, because Python does not
+require you to use an isolated environment, and Python projects do not have a
+unified install command.
 
-If this doesn't work, ALE does have an option to "find up" patterns of
-virtualenv directories, in case they are stored near the project. See
-`help g:ale_virtualenv_dirnames`. This "find up" is like what ALE does for
-node_modules/. So, if the pyenv environment doesn't get picked up in Vim, a
-workaround to feed ALE the correct tool versions is to create a symlink to the
-virtualenv matching one of ALE's virtualenv directory patterns.
+I'm using [mise](https://github.com/jdx/mise) to manage Python versions and
+virtualenvs, so while inside the project folder, I can set the virtualenv the
+project should use with a `.mise.local.toml` like the following.
 
-```sh
-ln -s ~/.pyenv/versions/virtualenv-name-here /path/to/project/.venv
+```toml
+[tools]
+python = "3.13"
+
+[env]
+_.python.venv = { path = ".venv", create = true }
 ```
+
+Then `mise trust` the file. Then follow the project's install instructions.
+
+The `.mise.local.toml` above activates the local Python install whenever you're
+inside the project folder. When editing project files,
+[vim-rooter](https://github.com/airblade/vim-rooter) should automatically `cd`
+into the folder, and therefore activate the local Python install and tool
+versions, for Vim and ALE.
 
 #### Global tools
 
-My default pyenv approach, above, confounds finding a _global_ tool, in addition
-to local tools. pyenv tends to make only 1 virtualenv's tools available at a
-time. Say a project chooses not to specify/depend on a tool, but it still helps
-my local development. In this case, installing a tool with
-[uv](https://github.com/astral-sh/uv) makes the tool available on my `PATH`,
-while isolating the tool's environment. The tool is not inflicted upon the
-project nor the developer's global Python install. I like the following tools.
+Active virtualenvs confound finding a _global_ tool, in addition to local tools;
+only 1 virtualenv's installed tools tend to be available at a time.
+
+Say a project chooses not to specify/depend on a tool, but it still helps my
+local development. In this case, installing a tool with
+[`uv tool install`](https://github.com/astral-sh/uv) makes the tool available on
+my `PATH`, while isolating the tool's environment. The tool is not inflicted
+upon the project nor the developer's global Python install. I like the following
+tools.
 
 ```sh
-brew install uv
+brew install uv  # if not already installed by ~/.config/mise/config.toml
+
 uv tool install mypy
 uv tool install python-lsp-server
 uv tool install ruff
 ```
 
-Note however that tools installed via `uv tool install` will not have access to
-the project's 3rd party dependencies, for example `python-lsp-server` analyzing
-3rd party types, because the tool's environment is separate from the project's
-environment. It would only have access to first party types and standard library
-types. As a last resort, I directly install into the project's virtualenv. For
-example:
+Note however that global, isolated tools installed via `uv tool install` will
+not have access to the project's 3rd party dependencies. For example,
+`python-lsp-server` won't analyze 3rd party types; it only has access to first
+party types and standard library types. As a last resort, I directly install
+into the project's virtualenv. For example:
 
 ```sh
 pip install python-lsp-server
@@ -83,6 +89,8 @@ dependency of the project.
 Individual projects can conflict with my general dotfiles settings. For example,
 my Vim autofix settings are liberal. When interacting with legacy projects
 without enforced code style, autofix can inflict a ton of noise.
+
+> ![CAUTION] Replace direnv with mise.
 
 I'm already using [direnv](https://direnv.net/) dotfiles for per-project
 environment variables. With 2 project folder dotfiles, .envrc and .vimrc.local,

--- a/.editorconfig
+++ b/.editorconfig
@@ -13,6 +13,9 @@ insert_final_newline = true
 indent_style = space
 indent_size = 2
 
+[*.ambr]
+trim_trailing_whitespace = false
+
 [*.md]
 indent_size = 4
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,11 @@
 *.pyc
 *~
 .~*
-.direnv
 .dotfiles
 .env*
 .eslintcache
 .idea
+.mise.local.toml
 .project
 .python-version
 .settings

--- a/.vimrc
+++ b/.vimrc
@@ -293,6 +293,9 @@ let g:markdown_fenced_languages = [
 
 let g:mkdp_auto_close = 1
 
+" mise.nvim
+lua require('mise').setup()
+
 " vim-rooter
 let g:rooter_patterns = [
 \  '.git',

--- a/.vimrc
+++ b/.vimrc
@@ -119,7 +119,7 @@ endif
 
 " Speed up startup with a Vim-dedicated virtualenv.
 "
-" I created it with the following. For more info, see :help python-virtualenv.
+" Create it with the following. For more info, see :help python-virtualenv.
 "
 " ```sh
 " python -m venv ~/.cache/py3nvim

--- a/.vimrc
+++ b/.vimrc
@@ -294,7 +294,9 @@ let g:markdown_fenced_languages = [
 let g:mkdp_auto_close = 1
 
 " mise.nvim
-lua require('mise').setup()
+if has('nvim')
+  lua require('mise').setup()
+endif
 
 " vim-rooter
 let g:rooter_patterns = [

--- a/.vimrc
+++ b/.vimrc
@@ -21,9 +21,9 @@ Plug 'andymass/vim-matchup'
 Plug 'ap/vim-css-color'
 Plug 'cocopon/iceberg.vim'
 Plug 'dense-analysis/ale'
-Plug 'direnv/direnv.vim'
 Plug 'dominickng/fzf-session.vim'
 Plug 'editorconfig/editorconfig-vim'
+Plug 'ejrichards/mise.nvim'
 Plug 'Exafunction/codeium.vim'
 Plug 'iamcco/markdown-preview.nvim', { 'do': { -> mkdp#util#install() } }
 Plug 'inkarkat/vim-ingo-library'
@@ -117,9 +117,15 @@ if has("gui_running")
   set macmeta
 endif
 
-" Speed up startup with a Vim-dedicated virtualenv. Follow setup instructions
-" in :help python-virtualenv.
-let g:python3_host_prog="~/.pyenv/versions/py3nvim/bin/python"
+" Speed up startup with a Vim-dedicated virtualenv.
+"
+" I created it with the following. For more info, see :help python-virtualenv.
+"
+" ```sh
+" python -m venv ~/.cache/py3nvim
+" ~/.cache/py3nvim/bin/python -m pip install pynvim
+" ```
+let g:python3_host_prog="~/.cache/py3nvim/bin/python"
 
 let mapleader = ","
 let maplocalleader = ","

--- a/.zshrc
+++ b/.zshrc
@@ -28,6 +28,7 @@ zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}'
 path=(
   ~/.bin
   $HOME/.cargo/bin
+  $HOME/.local/bin
   $HOME/brew/bin
   /usr/local/bin
   /usr/local/opt/ruby/bin

--- a/.zshrc
+++ b/.zshrc
@@ -28,7 +28,6 @@ zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}'
 path=(
   ~/.bin
   $HOME/.cargo/bin
-  $HOME/.local/bin
   $HOME/brew/bin
   /usr/local/bin
   /usr/local/opt/ruby/bin

--- a/.zshrc
+++ b/.zshrc
@@ -1,7 +1,5 @@
 export EDITOR=nvim
 
-export VOLTA_HOME="$HOME/.volta"
-
 # Global, misc. shell settings
 
 [ -z "$HISTFILE" ] && HISTFILE="$HOME/.zsh_history"
@@ -32,7 +30,6 @@ path=(
   $HOME/.cargo/bin
   $HOME/.local/bin
   $HOME/brew/bin
-  $VOLTA_HOME/bin
   /usr/local/bin
   /usr/local/opt/ruby/bin
   /usr/bin
@@ -73,7 +70,6 @@ alias ls='eza'
 [[ -s "$HOME/.hostspecific" ]] && source "$HOME/.hostspecific"
 # Source environment variables from a dotenv file
 [[ -s "$HOME/.env" ]] && export $(cat "$HOME/.env" | xargs)
-eval "$(direnv hook zsh)"
 
 function zvm_after_init() {
   # zsh-vi-mode
@@ -102,11 +98,7 @@ eval "$(zoxide init zsh)"
 
 # Enable various version managers
 
-[[ -s "$HOME/.asdf/asdf.sh" ]] && source "$HOME/.asdf/asdf.sh"
-[[ -s "$HOME/.cargo/env" ]] && . "$HOME/.cargo/env"
-[[ -s "$HOME/.gvm/scripts/gvm" ]] && source "$HOME/.gvm/scripts/gvm"
-if which pyenv > /dev/null; then eval "$(pyenv init - --no-rehash)"; fi
-if which pyenv-virtualenv-init > /dev/null; then eval "$(pyenv virtualenv-init -)"; fi
+if which mise > /dev/null; then eval "$(mise activate zsh)"; fi
 
 # Enable iTerm shell integration
 


### PR DESCRIPTION
I previously considered asdf to manage all my tool versions. [mise](https://github.com/jdx/mise) fulfills the promise of asdf with acceptable performance. It also handles environment variables, replacing direnv.

# Changes

* Remove references to asdf, direnv, gvm, pyenv, Volta
* Track my preferred global tool versions
  * (I foresee these versions being different between devices. It should be possible to override with an uncommitted mise.local.toml.)

# Manual Migration Steps

```zsh
brew install mise
brew uninstall asdf direnv gvm pyenv pyenv-virtualenv volta
```

Replace any project `.envrc` files with `.mise.local.toml` files with an `[env]` section.

# TODO

- [ ] Replace direnv for project-local Vim configuration