### PR TITLE
Switch from ALE to Neovim equivalents

### DIFF
--- a/.docs/PROJECT_LOCAL_CONFIGURATION.md
+++ b/.docs/PROJECT_LOCAL_CONFIGURATION.md
@@ -1,33 +1,70 @@
 # Project-Local Configuration
 
+This document describes how to configure project-local tooling in the following
+environments, if any configuration is necessary.
+
+- Vim
+- Terminal (e.g. `$PATH`)
+
+Wherever manual configuration is necessary, it is recommended to have [mise]
+installed.
+
 ## Tool Versions
 
 ### JavaScript
 
-✅ **JavaScript project-local tooling should be picked up automatically.**
-
 JavaScript projects already install their tooling locally to the project's
-node_modules/. [ALE](https://github.com/dense-analysis/ale) looks up for the
-nearest node_modules/ with the relevant tool, e.g. Prettier.
+`node_modules/`. As long as tools or the `$PATH` know to look there first.
 
-If a project doesn't specify the tool, ALE can fall back to a global install of
-the tool. Note the global tool will not necessarily have access to the project's
-3rd party dependencies, e.g. for type checking.
+- ✅ Vim plugins automatically look up the nearest `node_modules/` with the
+  relevant tool, e.g. Prettier. Nothing extra to configure.
+- ❎ The terminal can add the `node_modules/.bin` folder to the `$PATH`
+  automatically upon `cd`ing into a folder containing a mise `.mise.local.toml`
+  like the following.
+
+```toml
+# /path/to/cloned/project/.mise.local.toml
+
+[tools]
+node = '22'
+
+[env]
+_.path = ['{{config_root}}/node_modules/.bin']
+```
+
+In the terminal, after `cd`ing into the project folder, calling `prettier` will
+refer to the project's installed version of `prettier`.
+
+Without mise, a terminal user can directly call
+`node_modules/.bin/name-of-tool`, `npx name-of-tool`, or
+`pnpm exec name-of-tool`.
+
+#### Global tools
+
+If a project doesn't specify the tool, linting and formatting "look up" behavior
+can fall back to a global install of the tool. Same for the terminal as long as
+the global tool is on on `$PATH`. Note the global tool will not necessarily have
+access to the project's 3rd party dependencies, e.g. for type checking.
 
 ### Python
 
-❎ **Python project-local tooling should be picked up automatically,** with
-caveats.
+❎ **Python project-local tooling should be picked up automatically** by Vim and
+terminal, similar to JavaScript, _provided manual Python version
+configuration/activation with mise_.
 
 Python project dependencies require an extra step, because Python does not
 require you to use an isolated environment, and Python projects do not have a
 unified install command.
 
-I'm using [mise](https://github.com/jdx/mise) to manage Python versions and
-virtualenvs, so while inside the project folder, I can set the virtualenv the
-project should use with a `.mise.local.toml` like the following.
+mise serves double duty in these dotfiles, to manage _system_ Python versions
+and _local_ virtualenvs.
+
+While inside the project folder, I can set the virtualenv the project should use
+with a `.mise.local.toml` like the following.
 
 ```toml
+# /path/to/cloned/project/.mise.local.toml
+
 [tools]
 python = "3.13"
 
@@ -35,13 +72,13 @@ python = "3.13"
 _.python.venv = { path = ".venv", create = true }
 ```
 
-Then `mise trust` the file. Then follow the project's install instructions.
+Then `cd` into the folder with the `.mise.local.toml`. Then follow the project's
+install instructions. It should install into `/path/to/cloned/project/.venv`.
 
-The `.mise.local.toml` above activates the local Python install whenever you're
-inside the project folder. When editing project files,
-[vim-rooter](https://github.com/airblade/vim-rooter) should automatically `cd`
-into the folder, and therefore activate the local Python install and tool
-versions, for Vim and ALE.
+In the terminal, the mise file activates the local Python install whenever
+you're inside the project folder. When editing project files, [vim-rooter]
+should automatically `cd` Vim into the folder, and therefore activate the local
+Python install and tool versions for Vim.
 
 #### Global tools
 
@@ -52,8 +89,10 @@ Say a project chooses not to specify/depend on a tool, but it still helps my
 local development. In this case, installing a tool with
 [`uv tool install`](https://github.com/astral-sh/uv) makes the tool available on
 my `PATH`, while isolating the tool's environment. The tool is not inflicted
-upon the project nor the developer's global Python install. I like the following
-tools.
+upon the project nor the developer's global Python install (which could be
+further lost by switching global versions).
+
+I personally like the following tools.
 
 ```sh
 brew install uv  # if not already installed by ~/.config/mise/config.toml
@@ -73,12 +112,10 @@ into the project's virtualenv. For example:
 pip install python-lsp-server
 ```
 
-`pip install` is at the risk of mucking up the project's environment working
-with other team members. Be careful when freezing and updating the project's
-dependencies.
-
-If you want an easier time, rally for your global tool to be an official, local
-dependency of the project.
+This direct install is at the risk of mucking up the project's environment
+working with other team members. Be careful when freezing and updating the
+project's dependencies. If you want an easier time, rally for your global tool
+to be an official, local dependency of the project.
 
 ### Monorepos
 
@@ -90,17 +127,31 @@ Individual projects can conflict with my general dotfiles settings. For example,
 my Vim autofix settings are liberal. When interacting with legacy projects
 without enforced code style, autofix can inflict a ton of noise. My editor ought
 to be configured per-project, instead of every project bending to me. Enter
-[vim-localvimrc](https://github.com/embear/vim-localvimrc) and per-project
-`.lvimrc` files.
+[vim-localvimrc][vim-localvimrc] and per-project `.lvimrc` files.
 
-In the following example, the project-local `.lvimrc` disables Prettier for all
-files within that project, and uses a different set of Python linters than the
-global set in [~/.vimrc](../.vimrc).
+In the following example, the project-local `.lvimrc` disables formatting for
+all JavaScript files within that project, and uses a different set of Python
+linters than the global set in
+[~/.vim/lua/linting.lua](../.vim/lua/linting.lua).
 
 ```vim
-" .lvimrc
-let b:ale_fix_on_save_ignore = ['prettier']
-let b:ale_linters = {
-\   'python': ['mypy', 'pylsp']
-\}
+" /path/to/cloned/project/.lvimrc
+
+lua << EOF
+-- Disable Prettier for this project
+require('conform').setup({
+  formatters_by_ft = {
+    javascript = {},  -- empty to disable
+  },
+})
+
+-- Use specific Python linters for this project
+require('lint').linters_by_ft = {
+  python = {'pylint'},
+}
+EOF
 ```
+
+[mise]: https://github.com/jdx/mise
+[vim-localvimrc]: https://github.com/embear/vim-localvimrc
+[vim-rooter]: https://github.com/airblade/vim-rooter

--- a/.vim/ftplugin/json.vim
+++ b/.vim/ftplugin/json.vim
@@ -1,1 +1,0 @@
-let b:ale_fix_on_save = 0

--- a/.vim/ftplugin/markdown.vim
+++ b/.vim/ftplugin/markdown.vim
@@ -1,5 +1,3 @@
-let b:ale_fix_on_save = 0
-
 augroup textobj_quote
   autocmd!
   autocmd FileType markdown call textobj#quote#init()

--- a/.vim/lua/completion.lua
+++ b/.vim/lua/completion.lua
@@ -1,0 +1,2 @@
+require("blink.cmp").setup({
+})

--- a/.vim/lua/format.lua
+++ b/.vim/lua/format.lua
@@ -1,0 +1,29 @@
+require('conform').setup({
+  formatters_by_ft = {
+    astro = { 'biome', 'stylelint', 'prettier' },
+    css = { 'stylelint', 'biome', 'prettier' },
+    html = { 'prettier' },
+    javascript = { 'biome', 'prettier' },
+    javascriptreact = { 'biome', 'prettier' },
+    json = { 'fixjson', 'biome', 'prettier' },
+    markdown = { 'prettier' },
+    python = { 'ruff_format' },
+    rust = { 'rustfmt' },
+    sh = { 'shfmt' },
+    svelte = { 'biome', 'prettier' },
+    typescript = { 'biome', 'prettier' },
+    typescriptreact = { 'biome', 'prettier' },
+    vue = { 'biome', 'prettier' },
+  },
+
+  -- Format on save
+  format_on_save = {
+    timeout_ms = 500,
+    lsp_format = "fallback",
+  },
+})
+
+-- Manual format keymap
+vim.keymap.set({ 'n', 'v' }, '<leader>fo', function()
+  require('conform').format({ async = true, lsp_fallback = true })
+end, { desc = 'Format buffer' })

--- a/.vim/lua/format.lua
+++ b/.vim/lua/format.lua
@@ -16,11 +16,18 @@ require('conform').setup({
     vue = { 'biome', 'prettier' },
   },
 
-  -- Format on save
-  format_on_save = {
-    timeout_ms = 500,
-    lsp_format = "fallback",
-  },
+  -- Format on save, for most filetypes
+  format_on_save = function(bufnr)
+    local filetype = vim.bo[bufnr].filetype
+    if filetype == "json" or filetype == "markdown" then
+      return nil
+    end
+
+    return {
+      timeout_ms = 500,
+      lsp_format = "fallback",
+    }
+  end,
 })
 
 -- Manual format keymap

--- a/.vim/lua/linting.lua
+++ b/.vim/lua/linting.lua
@@ -1,0 +1,21 @@
+require("lint").linters_by_ft = {
+  astro = { "biomejs", "eslint", "stylelint" },
+  css = { "stylelint", "biomejs" },
+  javascript = { "biomejs", "eslint" },
+  javascriptreact = { "biomejs", "eslint" },
+  python = { "mypy", "ruff" },
+  typescript = { "biomejs", "eslint" },
+  typescriptreact = { "biomejs", "eslint" },
+  vue = { "biomejs", "eslint" },
+}
+
+vim.api.nvim_create_autocmd({
+  "BufEnter",
+  "BufWritePost",
+  "TextChanged",
+  "TextChangedI",
+}, {
+  callback = function()
+    require("lint").try_lint()
+  end,
+})

--- a/.vim/lua/lsp.lua
+++ b/.vim/lua/lsp.lua
@@ -15,7 +15,6 @@ vim.api.nvim_create_autocmd('LspAttach', {
     vim.keymap.set('n', 'gD', vim.lsp.buf.declaration, opts)
     vim.keymap.set('n', 'gi', vim.lsp.buf.implementation, opts)
     vim.keymap.set('n', 'gr', vim.lsp.buf.references, opts)
-    vim.keymap.set('n', 'gt', vim.lsp.buf.type_definition, opts)
 
     -- Documentation
     vim.keymap.set('n', 'gk', vim.lsp.buf.hover, opts)

--- a/.vim/lua/lsp.lua
+++ b/.vim/lua/lsp.lua
@@ -1,0 +1,33 @@
+vim.lsp.enable('astro')
+vim.lsp.enable('biome')
+vim.lsp.enable('eslint')
+vim.lsp.enable('pylsp')
+vim.lsp.enable('pyright')
+vim.lsp.enable('ruff')
+vim.lsp.enable('ts_ls')
+vim.lsp.enable('vue_ls')
+
+vim.api.nvim_create_autocmd('LspAttach', {
+  group = vim.api.nvim_create_augroup('my.lsp', {}),
+  callback = function(args)
+    -- Navigation
+    vim.keymap.set('n', 'gd', vim.lsp.buf.definition, opts)
+    vim.keymap.set('n', 'gD', vim.lsp.buf.declaration, opts)
+    vim.keymap.set('n', 'gi', vim.lsp.buf.implementation, opts)
+    vim.keymap.set('n', 'gr', vim.lsp.buf.references, opts)
+    vim.keymap.set('n', 'gt', vim.lsp.buf.type_definition, opts)
+
+    -- Documentation
+    vim.keymap.set('n', 'gk', vim.lsp.buf.hover, opts)
+    vim.keymap.set('n', 'gK', vim.lsp.buf.signature_help, opts)
+
+    -- Refactoring
+    vim.keymap.set('n', '<leader>rn', vim.lsp.buf.rename, opts)
+    vim.keymap.set('n', '<leader>ca', vim.lsp.buf.code_action, opts)
+
+    -- Diagnostics
+    vim.keymap.set('n', '[d', vim.diagnostic.goto_prev, opts)
+    vim.keymap.set('n', ']d', vim.diagnostic.goto_next, opts)
+    vim.keymap.set('n', '<leader>d', vim.diagnostic.open_float, opts)
+  end,
+})

--- a/.vimrc
+++ b/.vimrc
@@ -39,6 +39,7 @@ Plug 'machakann/vim-highlightedyank'
 Plug 'maxbrunsfeld/vim-yankstack'
 Plug 'michaeljsmith/vim-indent-object'
 if has('nvim')
+  Plug 'mfussenegger/nvim-lint'
   Plug 'neovim/nvim-lspconfig'
   Plug 'nvim-lua/plenary.nvim'
   " Pin to legacy `master` branch.
@@ -275,6 +276,7 @@ if has('nvim')
 lua require('ai')
 lua require('completion')
 lua require('format')
+lua require('linting')
 lua require('lsp')
 lua require('mise').setup()
 lua require('syntax')

--- a/.vimrc
+++ b/.vimrc
@@ -285,6 +285,7 @@ let g:markdown_fenced_languages = [
 let g:mkdp_auto_close = 1
 
 " vim-rooter
+let g:rooter_cd_cmd = 'lcd'
 let g:rooter_patterns = [
 \  '.git',
 \  'Cargo.toml',

--- a/.vimrc
+++ b/.vimrc
@@ -20,7 +20,6 @@ Plug 'airblade/vim-rooter'
 Plug 'andymass/vim-matchup'
 Plug 'ap/vim-css-color'
 Plug 'cocopon/iceberg.vim'
-Plug 'dense-analysis/ale'
 Plug 'dominickng/fzf-session.vim'
 Plug 'ejrichards/mise.nvim'
 Plug 'embear/vim-localvimrc'
@@ -38,9 +37,9 @@ Plug 'justinmk/vim-sneak'
 Plug 'kana/vim-textobj-user'
 Plug 'machakann/vim-highlightedyank'
 Plug 'maxbrunsfeld/vim-yankstack'
-Plug 'maximbaz/lightline-ale'
 Plug 'michaeljsmith/vim-indent-object'
 if has('nvim')
+  Plug 'neovim/nvim-lspconfig'
   Plug 'nvim-lua/plenary.nvim'
   " Pin to legacy `master` branch.
   " TODO: upgrade to breaking `main` branch.
@@ -139,53 +138,6 @@ let maplocalleader = ","
 " -------------------------
 "
 
-" ale
-let g:ale_completion_enabled = 1
-let g:ale_fix_on_save = 1
-let g:ale_floating_preview = 1
-let g:ale_floating_window_border = [' ', ' ', ' ', ' ', ' ', ' ']
-inoremap <silent><expr> <Tab> pumvisible() ? "\<C-n>" : "\<TAB>"
-inoremap <silent><expr> <S-Tab> pumvisible() ? "\<C-p>" : "\<S-TAB>"
-map <leader>u :ALEFindReferences<CR>
-nnoremap <M-LeftMouse> <LeftMouse>:ALEGoToDefinition<CR>
-nnoremap <silent> gd :ALEGoToDefinition<CR>
-nnoremap <silent> gds :ALEGoToDefinition -split<CR>
-nnoremap <silent> gdt :ALEGoToDefinition -tab<CR>
-nnoremap <silent> gdv :ALEGoToDefinition -vsplit<CR>
-nnoremap <silent> gk :ALEDetail<CR>
-let g:ale_linter_aliases = {'astro': ['css', 'javascript', 'typescript']}
-let g:ale_fixers = {
-\   'astro': ['biome', 'eslint', 'stylelint', 'prettier'],
-\   'css': ['stylelint', 'biome', 'prettier'],
-\   'javascript': ['biome', 'eslint', 'prettier'],
-\   'javascriptreact': ['biome', 'eslint', 'prettier'],
-\   'json': ['fixjson', 'biome', 'prettier'],
-\   'html': ['prettier'],
-\   'markdown': ['remark-lint', 'prettier'],
-\   'python': ['ruff', 'ruff_format'],
-\   'rust': ['rustfmt'],
-\   'sh': ['shfmt'],
-\   'svelte': ['biome', 'eslint', 'prettier'],
-\   'typescript': ['biome', 'eslint', 'prettier'],
-\   'typescriptreact': ['biome', 'eslint', 'prettier'],
-\   'vue': ['biome', 'eslint', 'prettier'],
-\}
-" TODO: add tsserver to astro. tsserver seems to parse a whole Astro file as TypeScript.
-let g:ale_linters = {
-\   'astro': ['biome', 'eslint', 'stylelint'],
-\   'css': ['stylelint', 'biome'],
-\   'handlebars': ['ember-template-lint', 'glint'],
-\   'html': [],
-\   'javascript': ['biome', 'eslint', 'tsserver'],
-\   'javascriptreact': ['biome', 'eslint', 'tsserver'],
-\   'markdown': ['remark-lint'],
-\   'python': ['mypy', 'pylsp', 'pyright', 'ruff'],
-\   'typescript': ['biome', 'eslint', 'tsserver'],
-\   'typescriptreact': ['biome', 'eslint', 'tsserver'],
-\   'vue': ['biome', 'eslint', 'vls'],
-\}
-set omnifunc=ale#completion#OmniFunc
-
 " codeium
 let g:codeium_no_map_tab = 1
 imap <script><silent><nowait><expr> <M-Tab> codeium#Accept()
@@ -241,6 +193,7 @@ let g:lightline = {
 \     'right': '',
 \   },
 \}
+" TODO: these lines and the above ALE config are unused. Switch from lightline-ale to Neovim diagnostic output.
 let g:lightline#ale#indicator_warnings = '◆ '
 let g:lightline#ale#indicator_errors = '✗ '
 let g:lightline#ale#indicator_ok = '✓'
@@ -317,6 +270,7 @@ let g:sneak#label = 1
 
 if has('nvim')
 lua require('ai')
+lua require('lsp')
 lua require('mise').setup()
 lua require('syntax')
 endif

--- a/.vimrc
+++ b/.vimrc
@@ -45,6 +45,8 @@ if has('nvim')
   " TODO: upgrade to breaking `main` branch.
   Plug 'nvim-treesitter/nvim-treesitter', {'branch': 'master', 'do': ':TSUpdate'}
   Plug 'olimorris/codecompanion.nvim'
+  " Pin to latest tagged release, to automatically install optional Rust fuzzy finder.
+  Plug 'saghen/blink.cmp', { 'tag': '*' }
 endif
 Plug 'osyo-manga/vim-over'
 Plug 'preservim/vim-textobj-quote'
@@ -270,6 +272,7 @@ let g:sneak#label = 1
 
 if has('nvim')
 lua require('ai')
+lua require('completion')
 lua require('lsp')
 lua require('mise').setup()
 lua require('syntax')

--- a/.vimrc
+++ b/.vimrc
@@ -168,9 +168,9 @@ let g:lightline = {
 \     'lineinfo': '%c%V',
 \   },
 \   'component_expand': {
-\     'linter_warnings': 'lightline#ale#warnings',
-\     'linter_errors': 'lightline#ale#errors',
-\     'linter_ok': 'lightline#ale#ok',
+\     'linter_warnings': 'LightlineLinterWarnings',
+\     'linter_errors': 'LightlineLinterErrors',
+\     'linter_ok': 'LightlineLinterOK',
 \   },
 \   'component_function': {
 \     'gitbranch': 'LightlineFugitive',
@@ -197,10 +197,36 @@ let g:lightline = {
 \     'right': '',
 \   },
 \}
-" TODO: these lines and the above ALE config are unused. Switch from lightline-ale to Neovim diagnostic output.
-let g:lightline#ale#indicator_warnings = '◆ '
-let g:lightline#ale#indicator_errors = '✗ '
-let g:lightline#ale#indicator_ok = '✓'
+
+" Lightline auto-refresh when diagnostics change
+autocmd User LspDiagnosticsChanged call lightline#update()
+autocmd DiagnosticChanged * call lightline#update()
+
+" Lightline diagnostic functions for nvim-lspconfig and nvim-lint
+function! LightlineLinterWarnings() abort
+  if !has('nvim')
+    return ''
+  endif
+  let l:counts = luaeval('(vim.diagnostic.count(0)[vim.diagnostic.severity.WARN] or 0)')
+  return l:counts == 0 ? '' : '◆ ' . l:counts
+endfunction
+
+function! LightlineLinterErrors() abort
+  if !has('nvim')
+    return ''
+  endif
+  let l:counts = luaeval('(vim.diagnostic.count(0)[vim.diagnostic.severity.ERROR] or 0)')
+  return l:counts == 0 ? '' : '✗ ' . l:counts
+endfunction
+
+function! LightlineLinterOK() abort
+  if !has('nvim')
+    return ''
+  endif
+  let l:total = luaeval('#vim.diagnostic.get(0)')
+  return l:total == 0 ? '✓' : ''
+endfunction
+
 function! LightlineReadonly()
   return &readonly ? '' : ''
 endfunction

--- a/.vimrc
+++ b/.vimrc
@@ -47,6 +47,7 @@ if has('nvim')
   Plug 'olimorris/codecompanion.nvim'
   " Pin to latest tagged release, to automatically install optional Rust fuzzy finder.
   Plug 'saghen/blink.cmp', { 'tag': '*' }
+  Plug 'stevearc/conform.nvim'
 endif
 Plug 'osyo-manga/vim-over'
 Plug 'preservim/vim-textobj-quote'
@@ -273,6 +274,7 @@ let g:sneak#label = 1
 if has('nvim')
 lua require('ai')
 lua require('completion')
+lua require('format')
 lua require('lsp')
 lua require('mise').setup()
 lua require('syntax')


### PR DESCRIPTION
ALE has been my single most valuable Vim plugin since it came out. Non-blocking lint as you type was a game changer. Alas, the Neovim community has moved on. The mindshare favors splitting the monolith of concepts combined by ALE into separate concepts: LSPs, completion, format, and lint.

# Changes

* Switch to [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig)
* Switch to [blink.cmp](https://github.com/Saghen/blink.cmp)
* Switch to [conform.nvim](https://github.com/stevearc/conform.nvim/)
* Switch to [nvim-lint](https://github.com/mfussenegger/nvim-lint/)
  * Fix sync between vim-rooter cwd and nvim-lint
* Inline Lightline functions to display diagnostics, instead of ALE indicators
* Overhaul project-local docs
  * Remove mentions of specific tools like ALE