### PR TITLE
Fix dotfiles commits using non-personal email

### DIFF
--- a/.docs/MACHINE_LOCAL_CONFIGURATION.md
+++ b/.docs/MACHINE_LOCAL_CONFIGURATION.md
@@ -23,6 +23,9 @@ GIT_COMMITTER_EMAIL = "you@company.com"
 JJ_EMAIL = "you@company.com"
 ```
 
+These environment variables are for non-dotfiles repos. `dotfiles-env` pins
+dotfiles commits to my personal email.
+
 ## Theme
 
 ### Neovim Terminal

--- a/.vim/lua/local/mise/init.lua
+++ b/.vim/lua/local/mise/init.lua
@@ -1,0 +1,119 @@
+-- Local copy of `swapnilsm/mise.nvim` from branch `configure-scope` (47078b0).
+-- Loads `mise env --json` into `vim.env` on setup and on `DirChanged` for the
+-- configured scopes.
+
+local log = require("local.mise.log")
+
+local Mise = {}
+
+local defaults = {
+  run = "mise",
+  args = "env --json",
+  initial_path = vim.env.PATH,
+  unset_vars = true,
+  load_on_setup = true,
+  force_run = false,
+  cd_scope = { "global" },
+}
+
+local options
+
+local previous_vars = {}
+
+local function set_previous(data)
+  previous_vars = {}
+  for var_name, var_value in pairs(data) do
+    if var_name ~= "PATH" then
+      previous_vars[var_name] = var_value
+    end
+  end
+end
+
+local function get_data()
+  local full_command = options.run .. " " .. options.args
+  local env_sh = vim.fn.system(full_command)
+
+  if string.find(env_sh, "^mise") then
+    local first_line = string.match(env_sh, "^[^\n]*")
+    log.error(first_line)
+    return nil
+  end
+
+  local ok, data = pcall(vim.json.decode, env_sh)
+  if not ok or data == nil then
+    log.error('Invalid json returned by "' .. full_command .. '"')
+    return nil
+  end
+
+  return data
+end
+
+local function load_env(data)
+  if options.unset_vars then
+    for var_name, _ in pairs(previous_vars) do
+      vim.env[var_name] = nil
+    end
+  end
+
+  for var_name, var_value in pairs(data) do
+    vim.env[var_name] = var_value
+  end
+
+  set_previous(data)
+end
+
+local function dir_changed()
+  vim.env.PATH = options.initial_path
+
+  local data = get_data()
+  if data == nil then
+    return
+  end
+
+  load_env(data)
+end
+
+function Mise.setup(opt)
+  options = vim.tbl_deep_extend("force", {}, defaults, opt or {})
+
+  if vim.fn.executable(options.run) ~= 1 then
+    log.error('Cannot find "' .. options.run .. '" executable')
+    return
+  end
+
+  if options.run ~= "mise" and not options.force_run then
+    log.error(options.run .. ' not supported, set "force_run = true" in setup() if you know the data is correct.')
+    return
+  end
+
+  local data = get_data()
+  if data == nil then
+    return
+  end
+
+  if options.load_on_setup then
+    vim.env.PATH = options.initial_path
+    load_env(data)
+  else
+    set_previous(data)
+  end
+
+  local group = vim.api.nvim_create_augroup("mise.nvim", { clear = true })
+  vim.api.nvim_create_autocmd("DirChanged", {
+    group = group,
+    desc = "Run command to load env vars",
+    callback = function()
+      if vim.tbl_contains(options.cd_scope, vim.v.event.scope) then
+        dir_changed()
+      end
+    end,
+  })
+
+  vim.api.nvim_create_user_command("Mise", function()
+    log.info(vim.inspect(get_data()))
+  end, {
+    desc = "Mise",
+  })
+end
+
+return Mise

--- a/.vim/lua/local/mise/init.lua
+++ b/.vim/lua/local/mise/init.lua
@@ -19,6 +19,38 @@ local defaults = {
 local options
 
 local previous_vars = {}
+local protected_vars = {}
+
+local function is_protected(var_name)
+  return protected_vars[var_name] ~= nil
+end
+
+-- Capture startup git identity for dotfiles sessions and mark those vars as
+-- protected from mise env refreshes.
+local function set_protected_vars()
+  protected_vars = {}
+
+  if vim.env.DOTFILES_GIT_IDENTITY_LOCK ~= "1" then
+    return
+  end
+
+  local author_email = vim.env.GIT_AUTHOR_EMAIL
+  local committer_email = vim.env.GIT_COMMITTER_EMAIL
+
+  if author_email and author_email ~= "" then
+    protected_vars.GIT_AUTHOR_EMAIL = author_email
+  end
+
+  if committer_email and committer_email ~= "" then
+    protected_vars.GIT_COMMITTER_EMAIL = committer_email
+  end
+end
+
+local function restore_protected_vars()
+  for var_name, var_value in pairs(protected_vars) do
+    vim.env[var_name] = var_value
+  end
+end
 
 local function set_previous(data)
   previous_vars = {}
@@ -51,14 +83,19 @@ end
 local function load_env(data)
   if options.unset_vars then
     for var_name, _ in pairs(previous_vars) do
-      vim.env[var_name] = nil
+      if not is_protected(var_name) then
+        vim.env[var_name] = nil
+      end
     end
   end
 
   for var_name, var_value in pairs(data) do
-    vim.env[var_name] = var_value
+    if not is_protected(var_name) then
+      vim.env[var_name] = var_value
+    end
   end
 
+  restore_protected_vars()
   set_previous(data)
 end
 
@@ -75,6 +112,7 @@ end
 
 function Mise.setup(opt)
   options = vim.tbl_deep_extend("force", {}, defaults, opt or {})
+  set_protected_vars()
 
   if vim.fn.executable(options.run) ~= 1 then
     log.error('Cannot find "' .. options.run .. '" executable')

--- a/.vim/lua/local/mise/log.lua
+++ b/.vim/lua/local/mise/log.lua
@@ -1,0 +1,15 @@
+local log = {}
+
+function log.info(message)
+  vim.notify("mise.nvim: " .. message, vim.log.levels.INFO, { title = "mise.nvim" })
+end
+
+function log.warn(message)
+  vim.notify("mise.nvim: " .. message, vim.log.levels.WARN, { title = "mise.nvim" })
+end
+
+function log.error(message)
+  vim.notify("mise.nvim: " .. message, vim.log.levels.ERROR, { title = "mise.nvim" })
+end
+
+return log

--- a/.vim/lua/plugins/files.lua
+++ b/.vim/lua/plugins/files.lua
@@ -1,3 +1,7 @@
+require("local.mise").setup({
+  cd_scope = { "global", "window" },
+})
+
 return {
   -- Project root detection and `cd`
   {
@@ -12,43 +16,6 @@ return {
         "pyvenv.cfg",
       }
       vim.g.rooter_silent_chdir = 1
-    end,
-  },
-
-  -- Set env upon `cd`
-  {
-    "swapnilsm/mise.nvim",
-    branch = "configure-scope",
-    commit = "47078b0",
-    opts = {
-      cd_scope = { "global", "window" },
-    },
-    config = function(_, opts)
-      local author_email = vim.env.GIT_AUTHOR_EMAIL
-      local committer_email = vim.env.GIT_COMMITTER_EMAIL
-      local lock_identity = vim.env.DOTFILES_GIT_IDENTITY_LOCK == "1"
-
-      require("mise").setup(opts)
-
-      if not lock_identity then
-        return
-      end
-
-      local function restore_git_identity()
-        if author_email and author_email ~= "" then
-          vim.env.GIT_AUTHOR_EMAIL = author_email
-        end
-        if committer_email and committer_email ~= "" then
-          vim.env.GIT_COMMITTER_EMAIL = committer_email
-        end
-      end
-
-      restore_git_identity()
-      local group = vim.api.nvim_create_augroup("dotfiles_git_identity_lock", { clear = true })
-      vim.api.nvim_create_autocmd("DirChanged", {
-        group = group,
-        callback = restore_git_identity,
-      })
     end,
   },
 

--- a/.vim/lua/plugins/files.lua
+++ b/.vim/lua/plugins/files.lua
@@ -23,6 +23,33 @@ return {
     opts = {
       cd_scope = { "global", "window" },
     },
+    config = function(_, opts)
+      local author_email = vim.env.GIT_AUTHOR_EMAIL
+      local committer_email = vim.env.GIT_COMMITTER_EMAIL
+      local lock_identity = vim.env.DOTFILES_GIT_IDENTITY_LOCK == "1"
+
+      require("mise").setup(opts)
+
+      if not lock_identity then
+        return
+      end
+
+      local function restore_git_identity()
+        if author_email and author_email ~= "" then
+          vim.env.GIT_AUTHOR_EMAIL = author_email
+        end
+        if committer_email and committer_email ~= "" then
+          vim.env.GIT_COMMITTER_EMAIL = committer_email
+        end
+      end
+
+      restore_git_identity()
+      local group = vim.api.nvim_create_augroup("dotfiles_git_identity_lock", { clear = true })
+      vim.api.nvim_create_autocmd("DirChanged", {
+        group = group,
+        callback = restore_git_identity,
+      })
+    end,
   },
 
   -- Project-local Vim overrides

--- a/.zshenv
+++ b/.zshenv
@@ -1,4 +1,4 @@
-alias dotfiles-env='GIT_DIR="$HOME"/.dotfiles/ GIT_WORK_TREE="$HOME" GIT_AUTHOR_EMAIL="john.kurkowski@gmail.com" GIT_COMMITTER_EMAIL="john.kurkowski@gmail.com"'
+alias dotfiles-env='GIT_DIR="$HOME"/.dotfiles/ GIT_WORK_TREE="$HOME" GIT_AUTHOR_EMAIL="john.kurkowski@gmail.com" GIT_COMMITTER_EMAIL="john.kurkowski@gmail.com" DOTFILES_GIT_IDENTITY_LOCK=1'
 alias dotfiles='dotfiles-env git'
 
 # Grep dotfiles, using Ripgrep.

--- a/.zshenv
+++ b/.zshenv
@@ -1,4 +1,4 @@
-alias dotfiles-env='GIT_DIR="$HOME"/.dotfiles/ GIT_WORK_TREE="$HOME"'
+alias dotfiles-env='GIT_DIR="$HOME"/.dotfiles/ GIT_WORK_TREE="$HOME" GIT_AUTHOR_EMAIL="john.kurkowski@gmail.com" GIT_COMMITTER_EMAIL="john.kurkowski@gmail.com"'
 alias dotfiles='dotfiles-env git'
 
 # Grep dotfiles, using Ripgrep.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It is laid out exactly how it goes in the `$HOME` dir.
 
 ```zsh
 git clone --bare https://github.com/john-kurkowski/dotfiles.git $HOME/.dotfiles
-alias dotfiles-env='GIT_DIR="$HOME"/.dotfiles/ GIT_WORK_TREE="$HOME" GIT_AUTHOR_EMAIL="john.kurkowski@gmail.com" GIT_COMMITTER_EMAIL="john.kurkowski@gmail.com"'
+alias dotfiles-env='GIT_DIR="$HOME"/.dotfiles/ GIT_WORK_TREE="$HOME" GIT_AUTHOR_EMAIL="john.kurkowski@gmail.com" GIT_COMMITTER_EMAIL="john.kurkowski@gmail.com" DOTFILES_GIT_IDENTITY_LOCK=1'
 alias dotfiles='dotfiles-env git'
 dotfiles config --local core.worktree $HOME
 dotfiles config --local status.showUntrackedFiles no

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ It is laid out exactly how it goes in the `$HOME` dir.
 
 ```zsh
 git clone --bare https://github.com/john-kurkowski/dotfiles.git $HOME/.dotfiles
-alias dotfiles='GIT_DIR=$HOME/.dotfiles/ GIT_WORK_TREE=$HOME git'
+alias dotfiles-env='GIT_DIR="$HOME"/.dotfiles/ GIT_WORK_TREE="$HOME" GIT_AUTHOR_EMAIL="john.kurkowski@gmail.com" GIT_COMMITTER_EMAIL="john.kurkowski@gmail.com"'
+alias dotfiles='dotfiles-env git'
 dotfiles config --local core.worktree $HOME
 dotfiles config --local status.showUntrackedFiles no
-dotfiles config --local user.email john.kurkowski@gmail.com
 dotfiles checkout
 ```
 


### PR DESCRIPTION
I think cc1eff3276227bdc0d952d81a6ffa20978f0eee9 broke this.

# Changes

* Update alias to include overriding env vars
* Inline mise.nvim
  * It's small. I was relying on a fork.
* Protect identity vars in mise loader 